### PR TITLE
Fix: Simplify Device Routes and Refactor Auth Error Handling (#19)

### DIFF
--- a/server/src/api/routes/deviceRoutes.js
+++ b/server/src/api/routes/deviceRoutes.js
@@ -24,7 +24,7 @@ router.post('/register', authenticateFirebaseToken, async (req, res) => {
 });
 
 router.delete(
-  '/devices/:deviceId',
+  '/:deviceId',
   authenticateFirebaseToken,
   async (req, res) => {
     try {
@@ -35,10 +35,7 @@ router.delete(
         .status(200)
         .send({ success: true, message: 'Device deleted successfully' });
     } catch (error) {
-      if (error.message === 'Not Authorized') {
-        return res.status(403).send({ error: error.message });
-      }
-      if (error.message === 'Not authorized') {
+      if (error.message.toLowerCase().includes('not authorized')) {
         return res.status(403).send({ error: error.message });
       }
       console.error('Error in DELETE /api/devices/:deviceId:', error);


### PR DESCRIPTION
This PR resolves the issues identified in #19 by refactoring the device routes (`routes/deviceRoutes.js`).

1.  **Route Path Simplification:** The path for the `DELETE` endpoint was changed from `/devices/:deviceId` to **`/:deviceId`** to eliminate path redundancy when the router is mounted.
2.  **Error Handling Consolidation:** The redundant `if` checks for the `403 Not Authorized` error in the `DELETE` route were merged into a single, more robust check that handles variations in capitalization.